### PR TITLE
Fix PCA variant detection in name_variants function

### DIFF
--- a/R/functions.r
+++ b/R/functions.r
@@ -11,10 +11,10 @@ impute_full_dataset <- function(data) {
 
 name_variants <- function(formula) {
   variant_name <- "raw"
-  if (any(grepl("UMAP", as.character(formula))))
-    variant_name = "UMAP"
-  if (any(grepl("PCA", as.character(formula))))
+  if (any(grepl("PC_", as.character(formula))))
     variant_name = "PCA"
+  else if (any(grepl("UMAP_", as.character(formula))))
+    variant_name = "UMAP"
   paste0(as.character(formula[2]), "_", variant_name)
 }
 


### PR DESCRIPTION
This fixes a bug in the name_variants function where PCA components weren't being correctly identified. The issue was caused by the pattern matching looking for "PCA" instead of "PC_" in the formula strings.

Previously, formulas containing PCA components (named PC_1, PC_2, etc.) were being incorrectly labeled as "raw" in the final results table.

- Changed the pattern matching in name_variants to look for "PC_" instead of "PCA"
- Added else to the if statement to ensure mutual exclusivity between PCA and UMAP detection
- Results now correctly show the expected pattern of raw/PCA/UMAP variants